### PR TITLE
Updated component to work with moment.js exclusively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ typings/
 # dotenv environment variables file
 .env
 
+.idea

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A(nother) date time selector.
 This one...
 
 - Is a React Component.
-- Makes use of out-of-the-box Bootstrap 4 css classes for styling.
+- Uses Reactstrap bindings (Bootstrap 4)
 - Uses icons from [fontawesome](http://fontawesome.io/icons/ "Font Awesome Homepage")
 
 All internal date manipulation is achieved using [Moment.js](https://momentjs.com/docs/#/parsing/ "Moment.js Homepage")
@@ -14,13 +14,13 @@ The component renders an [input-group](https://getbootstrap.com/docs/4.0/compone
 
 ## Demo
 
-https://codesandbox.io/s/881mmkvlwl
+https://codesandbox.io/s/881mmkvlwl (outdated)
 
 ## Getting Started
 ### Install
 
 #### npm
-`npm add date-time-selector`
+`npm install --save date-time-selector`
 
 #### yarn
 `yarn add date-time-selector`
@@ -30,19 +30,26 @@ https://codesandbox.io/s/881mmkvlwl
 
 ### Import
 
-`import DateTimeSelector from 'date-time-selector'`
+`import {DateTimeSelector} from 'date-time-selector'`
 
 ### JSX
 
-`<DateTimeSelector> `
-
-`<DateTimeSelector onSelected={this.handleSelected} disableTime={true} format='L' default={moment()} />`
+```
+<DateTimeSelector 
+  onChange={this.onDateTimeChange} 
+  disableTime={true} 
+  format='L' 
+  defaultValue={moment()} 
+/>
+```
 
 ## Props
 
 | Prop | Type | Required | Description | Default |
 | :--- | :--- | :---: | :--- | :--- |
-| `default` | Object | | A moment.js object.  This will be the default value selected in the selector |  |
-| `onSelected` | Function | | Will be called when a date is submitted. The selected moment is the only argument. Can be null. | |
+| `defaultValue` | Object | | A moment.js object.  This will be the default value selected in the selector |  |
+| `onChange` | Function | | Will be called when a date is submitted or valid date is entered in the input. Argument passed into onChange is an object, containing `value` and `moment`. `value` - is value from input, `moment` - is a Moment object. | |
 | `format` | String | | [moment.js format string](https://momentjs.com/docs/#/displaying/format/). | 'L LTS' |
 | `disableTime` | Boolean | | Set it to `true` if you'd like to hide the time inputs. | false |
+| `buttonClasses` | String | | Additional classes for toggle button | |
+| `inputClasses` | String | | Additional classes for input | |

--- a/dist/DateTimeSelector.js
+++ b/dist/DateTimeSelector.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
@@ -27,8 +25,6 @@ var _moment = require('moment');
 var _moment2 = _interopRequireDefault(_moment);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -81,13 +77,12 @@ var DateTimeSelector = function (_React$Component) {
           isValid = _state.isValid,
           isCalendarVisible = _state.isCalendarVisible,
           mo = _state.moment;
-
       var _props = this.props,
           buttonClasses = _props.buttonClasses,
           inputClasses = _props.inputClasses,
           defaultValue = _props.defaultValue,
-          format = _props.format,
-          rest = _objectWithoutProperties(_props, ['buttonClasses', 'inputClasses', 'defaultValue', 'format']);
+          format = _props.format;
+
 
       var currentValue = value;
 
@@ -101,12 +96,11 @@ var DateTimeSelector = function (_React$Component) {
         _react2.default.createElement(
           _reactstrap.InputGroup,
           null,
-          _react2.default.createElement(_reactstrap.Input, _extends({
-            className: 'form-control ' + (isValid ? '' : 'is-invalid') + ' ' + inputClasses
-          }, rest, {
+          _react2.default.createElement(_reactstrap.Input, {
+            className: 'form-control ' + (isValid ? '' : 'is-invalid') + ' ' + inputClasses,
             value: currentValue,
             onChange: this.handleChange
-          })),
+          }),
           _react2.default.createElement(
             _reactstrap.InputGroupAddon,
             { addonType: 'append' },
@@ -124,7 +118,8 @@ var DateTimeSelector = function (_React$Component) {
           visible: isCalendarVisible,
           value: mo,
           onSubmit: this.handleCalendarSelection,
-          format: this.props.format
+          format: this.props.format,
+          disableTime: this.props.disableTime
         })
       );
     }
@@ -142,14 +137,16 @@ DateTimeSelector.propTypes = {
   onChange: _propTypes2.default.func,
   buttonClasses: _propTypes2.default.string,
   inputClasses: _propTypes2.default.string,
-  format: _propTypes2.default.string
+  format: _propTypes2.default.string,
+  disableTime: _propTypes2.default.bool
 };
 DateTimeSelector.defaultProps = {
   defaultValue: null,
   onChange: null,
   buttonClasses: '',
   inputClasses: '',
-  format: ''
+  format: '',
+  disableTime: false
 };
 
 var _initialiseProps = function _initialiseProps() {
@@ -175,7 +172,6 @@ var _initialiseProps = function _initialiseProps() {
   };
 
   this.toggleCalendar = function (event) {
-    console.log('in toggle', event);
     if (event) {
       if (event.target.closest('.picker')) return;
 

--- a/package.json
+++ b/package.json
@@ -13,13 +13,11 @@
     "clean": "rm -rf node_modules"
   },
   "dependencies": {
-    "date-time-parser": "1.0.3",
     "moment": "^2.19.1",
     "prop-types": "15.5.8",
     "react": "^16.1.1",
     "react-dom": "^16.1.1",
-    "react-transition-group": "^2.2.1",
-    "reactstrap": "next"
+    "reactstrap": "^7.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.16.0",

--- a/src/DateTimeSelector.js
+++ b/src/DateTimeSelector.js
@@ -22,7 +22,8 @@ export default class DateTimeSelector extends React.Component {
     onChange: PropTypes.func,
     buttonClasses: PropTypes.string,
     inputClasses: PropTypes.string,
-    format: PropTypes.string
+    format: PropTypes.string,
+    disableTime: PropTypes.bool
   }
 
   static defaultProps = {
@@ -30,7 +31,8 @@ export default class DateTimeSelector extends React.Component {
     onChange: null,
     buttonClasses: '',
     inputClasses: '',
-    format: ''
+    format: '',
+    disableTime: false
   }
 
   attachOutsideClickListener = () => {
@@ -72,7 +74,6 @@ export default class DateTimeSelector extends React.Component {
   }
 
   toggleCalendar = event => {
-    console.log('in toggle', event)
     if (event) {
       if (event.target.closest('.picker')) return
 
@@ -102,7 +103,7 @@ export default class DateTimeSelector extends React.Component {
 
   render () {
     const { value, isValid, isCalendarVisible, moment: mo } = this.state
-    const { buttonClasses, inputClasses, defaultValue, format, ...rest } = this.props
+    const { buttonClasses, inputClasses, defaultValue, format } = this.props
 
     let currentValue = value
 
@@ -115,7 +116,6 @@ export default class DateTimeSelector extends React.Component {
         <InputGroup>
           <Input
             className={`form-control ${isValid ? '' : 'is-invalid'} ${inputClasses}`}
-            {...rest}
             value={currentValue}
             onChange={this.handleChange}
           />
@@ -133,6 +133,7 @@ export default class DateTimeSelector extends React.Component {
           value={mo}
           onSubmit={this.handleCalendarSelection}
           format={this.props.format}
+          disableTime={this.props.disableTime}
         />
       </div>
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
+  integrity sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -1343,6 +1350,13 @@ dom-helpers@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
+dom-helpers@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
+  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
@@ -2558,6 +2572,11 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 js-yaml@3.x, js-yaml@^3.5.1, js-yaml@^3.7.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
@@ -2768,9 +2787,10 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
-lodash.isfunction@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz#4db709fc81bc4a8fd7127a458a5346c5cdce2c6b"
+lodash.isfunction@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
 
 lodash.isobject@^3.0.2:
   version "3.0.2"
@@ -2839,6 +2859,13 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -3244,9 +3271,10 @@ pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
-popper.js@^1.12.5:
-  version "1.12.9"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.9.tgz#0dfbc2dff96c451bb332edcfcfaaf566d331d5b3"
+popper.js@^1.14.1:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.7.tgz#e31ec06cfac6a97a53280c3e55e4e0c860e7738e"
+  integrity sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ==
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -3284,13 +3312,22 @@ prop-types@15.5.8:
   dependencies:
     fbjs "^0.8.9"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+prop-types@^15.6.1, prop-types@^15.6.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 prr@~0.0.0:
   version "0.0.0"
@@ -3333,12 +3370,23 @@ react-dom@^16.1.1:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-popper@^0.7.2:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.7.4.tgz#8649d539837e7c6f47bc9b24c9cf57a404e199a1"
+react-is@^16.8.1:
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
+  integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
+
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-popper@^0.10.4:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.10.4.tgz#af2a415ea22291edd504678d7afda8a6ee3295aa"
+  integrity sha1-rypBXqIike3VBGeNev2opu4ylao=
   dependencies:
-    popper.js "^1.12.5"
-    prop-types "^15.5.10"
+    popper.js "^1.14.1"
+    prop-types "^15.6.1"
 
 react-test-renderer@15.5.4:
   version "15.5.4"
@@ -3347,7 +3395,7 @@ react-test-renderer@15.5.4:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
-react-transition-group@^2.2.0, react-transition-group@^2.2.1:
+react-transition-group@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
   dependencies:
@@ -3358,6 +3406,16 @@ react-transition-group@^2.2.0, react-transition-group@^2.2.1:
     prop-types "^15.5.8"
     warning "^3.0.0"
 
+react-transition-group@^2.3.1:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.6.0.tgz#3c41cbdd9c044c5f8604d4e8d319e860919c9fae"
+  integrity sha512-VzZ+6k/adL3pJHo4PU/MHEPjW59/TGQtRsXC+wnxsx2mxjQKNHnDdJL/GpYuPJIsyHGjYbBQfIJ2JNOAdPc8GQ==
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+    react-lifecycles-compat "^3.0.4"
+
 react@^16.1.1:
   version "16.1.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.1.1.tgz#d5c4ef795507e3012282dd51261ff9c0e824fe1f"
@@ -3367,17 +3425,20 @@ react@^16.1.1:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-reactstrap@next:
-  version "5.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/reactstrap/-/reactstrap-5.0.0-alpha.3.tgz#d2b46821efdf8c0511d59c1020fa4cfda174afc9"
+reactstrap@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/reactstrap/-/reactstrap-7.1.0.tgz#fd7125901737a3001c8564c0f8b40e319eec23b2"
+  integrity sha512-wtc4RkgnGn1TsZ0AxOZ2OqT+b8YmCWZj/tErPujWLepxzlEEhveZGC+uDerdaHVSAzJUP2DTk605iper7hutQQ==
   dependencies:
+    "@babel/runtime" "^7.2.0"
     classnames "^2.2.3"
-    lodash.isfunction "^3.0.8"
+    lodash.isfunction "^3.0.9"
     lodash.isobject "^3.0.2"
     lodash.tonumber "^4.0.3"
     prop-types "^15.5.8"
-    react-popper "^0.7.2"
-    react-transition-group "^2.2.0"
+    react-lifecycles-compat "^3.0.4"
+    react-popper "^0.10.4"
+    react-transition-group "^2.3.1"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -3447,6 +3508,11 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,10 +1040,6 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chain-function@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
-
 chalk@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.1.tgz#509afb67066e7499f7eb3535c77445772ae2d019"
@@ -1108,7 +1104,7 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
-classnames@^2.2.3, classnames@^2.2.5:
+classnames@^2.2.3:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -1262,12 +1258,6 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-time-parser@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/date-time-parser/-/date-time-parser-1.0.3.tgz#8e52f43cf2ffb539b4d03d9e4e441bfe227cae6d"
-  dependencies:
-    moment "^2.19.1"
-
 debug@^2.1.1, debug@^2.2.0, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1345,10 +1335,6 @@ doctrine@^1.2.2:
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
-
-dom-helpers@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
 dom-helpers@^3.3.1:
   version "3.4.0"
@@ -3395,17 +3381,6 @@ react-test-renderer@15.5.4:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
-react-transition-group@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
-  dependencies:
-    chain-function "^1.0.0"
-    classnames "^2.2.5"
-    dom-helpers "^3.2.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.5.8"
-    warning "^3.0.0"
-
 react-transition-group@^2.3.1:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.6.0.tgz#3c41cbdd9c044c5f8604d4e8d319e860919c9fae"
@@ -4067,12 +4042,6 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
-
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
-  dependencies:
-    loose-envify "^1.0.0"
 
 watch@~0.10.0:
   version "0.10.0"


### PR DESCRIPTION
Hello! I found your component which uses exactly the same stack that I use (reactstrap, moment). I liked the calendar very much.

But right now documentation isn't correct. If you look at the demo, you will see that it operates with text value of the date and ignores "format" altogether. I need this to work with moment.js objects, because my backend stores date in another format, and I need to be able to display it in a frontend in many different ways (dependent on how user chooses date format).

So I decided to fork this, and improve and correct where necessary. You will need to change your code if you use this, so perharps it's better to bump version

List of changes:
* Updated "reactstrap" dependency to more recent one (7.0.0) but it could be less (when `<InputGroupButton>` changed to `<InputGroupAddon>`)
* Removed unneeded dependencies (date-time-parser, react-transition-group). Moment.js can parse dates and times without any problems. Transition groups were not used.
* Correctly closes on clicks outside of calendar. It adds and removes "global" listeners when nececcary. Fixes #1
* Removed `value` prop - now you can provide `defaultValue` of moment.js object to set initial value. After that it will manage internal value in the state and fire `onChange` when date is correct or selected from the calendar picker.
* Returned `format` and `disableTime` props.
* Probably something else...

What I did not do:
* Did not create new demo with all the options
* Did not change anything in the DateTimeRangeSelector (I don't need it).